### PR TITLE
Suppress exit code when  zsh/nearcolor is not available

### DIFF
--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -381,4 +381,4 @@ if [[ $(uname -a) = (#i)*darwin* ]] {
     FAST_HIGHLIGHT[chroma-man]=
 }
 
-[[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null || :
+[[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null || true

--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -381,4 +381,4 @@ if [[ $(uname -a) = (#i)*darwin* ]] {
     FAST_HIGHLIGHT[chroma-man]=
 }
 
-[[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null
+[[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null || :


### PR DESCRIPTION
The [last line](https://github.com/zdharma-continuum/fast-syntax-highlighting/blob/9a5a4a5199e7e480009e10433d0d8c5be91f31d4/fast-syntax-highlighting.plugin.zsh#L384) of `fast-syntax-highlighting.plugin.zsh` is

    [[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null

The `&>/dev/null` is clearly meant to suppress an error message when the plugin is used with versions of Zsh earlier than 5.7; they do not have the `zsh/nearcolor` module. It does not succeed in suppressing the exit code of `1`, however, [which causes trouble if you're paying attention to exit codes](https://github.com/agkozak/zcomet/issues/9). For the time being, I propose changing the line to

    [[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null || :

The `|| :` should ensure an exit code of `0`. fast-syntax-highlight *seems* to work quite well without `nearcolor`, though perhaps there are unusual terminals that would beg to differ. I think `|| :` completes the developer's original idea.