### PR TITLE
Restore compatibility with Zsh v4.3.11

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -33,7 +33,8 @@ typeset -g FAST_WORK_DIR
 : ${FAST_WORK_DIR:=$FAST_BASE_DIR}
 FAST_WORK_DIR=${~FAST_WORK_DIR}
 () {
-  emulate -L zsh -o extendedglob
+  emulate -L zsh
+  setopt EXTENDED_GLOB
   local -A map
   map=( "XDG:"    "${XDG_CONFIG_HOME:-$HOME/.config}/fsh/"
         "LOCAL:"  "/usr/local/share/fsh/"

--- a/fast-highlight
+++ b/fast-highlight
@@ -33,8 +33,10 @@ typeset -g FAST_WORK_DIR
 : ${FAST_WORK_DIR:=$FAST_BASE_DIR}
 FAST_WORK_DIR=${~FAST_WORK_DIR}
 () {
+  # We must not use emulate -o if we want to keep compatibility with Zsh < v.5.0
+  # See https://github.com/zdharma-continuum/fast-syntax-highlighting/pull/7
   emulate -L zsh
-  setopt EXTENDED_GLOB
+  setopt extendedglob 
   local -A map
   map=( "XDG:"    "${XDG_CONFIG_HOME:-$HOME/.config}/fsh/"
         "LOCAL:"  "/usr/local/share/fsh/"


### PR DESCRIPTION
As far as I can tell, the only thing stopping fast-syntax-highlighting from working perfectly as far back as Zsh v4.3.11 is the line

    emulate -L zsh -o extendedglob

Zsh < v5.0 does not have an `-o` option, but you can achieve the same thing with

    emulate -L zsh
    setopt EXTENDED_GLOB