### PR TITLE
highlight: parse #fff/#ffffff correctly

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -1148,7 +1148,7 @@ typeset -ga ZLAST_COMMANDS
         fi
       fi
     fi
-    if [[ $__arg = (#b)*'#'(([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])|([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F]))* || $__arg = (#b)*'rgb('(([0-9a-fA-F][0-9a-fA-F](#c0,1)),([0-9a-fA-F][0-9a-fA-F](#c0,1)),([0-9a-fA-F][0-9a-fA-F](#c0,1)))* ]]; then
+    if [[ $__arg = (#b)*'#'(([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])([0-9a-fA-F][0-9a-fA-F])|([0-9a-fA-F])([0-9a-fA-F])([0-9a-fA-F]))(|[^[:alnum:]]*) || $__arg = (#b)*'rgb('(([0-9a-fA-F][0-9a-fA-F](#c0,1)),([0-9a-fA-F][0-9a-fA-F](#c0,1)),([0-9a-fA-F][0-9a-fA-F](#c0,1)))* ]]; then
       if [[ -n $match[2] ]]; then
         if [[ $match[2] = ?? || $match[3] = ?? || $match[4] = ?? ]]; then 
           (( __start=_start_pos-__PBUFLEN, __end=_end_pos-__PBUFLEN, __start >= 0 )) && reply+=("$__start $__end bg=#${(l:2::0:)match[2]}${(l:2::0:)match[3]}${(l:2::0:)match[4]}")


### PR DESCRIPTION
This PR make sure f-sy-h only highlight a valid hex color code.

Before:
![a](https://user-images.githubusercontent.com/17017672/151292395-d95fd007-7eba-4304-a3cb-1f03080c56d5.png)


After:
![b](https://user-images.githubusercontent.com/17017672/151292406-373f070b-aff5-4b04-91ec-2d517cad1058.png)


