### PR TITLE
Use 'typeset -g' to avoid warning when WARN_CREATE_GLOBAL is set.

### DIFF
--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -318,7 +318,7 @@ add-zsh-hook preexec _zsh_highlight_preexec_hook 2>/dev/null || {
     print -r -- "$@" >>! /tmp/reply
 }
 
-ZSH_HIGHLIGHT_MAXLENGTH=10000
+typeset -g ZSH_HIGHLIGHT_MAXLENGTH=10000
 
 # Load zsh/parameter module if available
 zmodload zsh/parameter 2>/dev/null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

'typeset -g' to avoid warning when WARN_CREATE_GLOBAL is set.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh

```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
