### PR TITLE
feat(whatis): recognize section suffix

### DIFF
--- a/→chroma/-whatis.ch
+++ b/→chroma/-whatis.ch
@@ -3,7 +3,18 @@
 
 (( next_word = 2 | 8192 ))
 local THEFD check __first_call="$1" __wrd="$2" __start_pos="$3" __end_pos="$4"
-local __style
+local __style __term __section __section_flag
+
+# extact manual subsection
+# NOTE: __term should be separated from __wrd to prevent incorrect cache hits
+if command -v mandb > /dev/null; then
+    __term="${__wrd%.[0-8n](|p|type|const|head|perl)}"
+    __section="${${2#$__term}#.}"
+else
+    __term=$__wrd
+fi
+
+[[ -n $__section ]] && __section_flag="-s $__section"
 
 (( ! ${+FAST_HIGHLIGHT[whatis_chroma_callback_was_ran]} )) && \
         FAST_HIGHLIGHT[whatis_chroma_callback_was_ran]=0
@@ -97,7 +108,7 @@ else
                 print "$__wrd"
                 (( __start=__start_pos-${#PREBUFFER}, __end=__end_pos-${#PREBUFFER} ))
                 print "$__start/$__end"
-                LANG=C whatis "$__wrd" 2>/dev/null
+                LANG=C whatis "${(z)__section_flag}" "$__term" 2>/dev/null
             )
             command true # see above
             zle -F ${${FAST_HIGHLIGHT[whatis_chroma_zle_-F_have_-w_opt]:#0}:+-w} "$THEFD" -fast-whatis-chroma-callback
@@ -107,7 +118,7 @@ else
                 print "$__wrd"
                 (( __start=__start_pos-${#PREBUFFER}, __end=__end_pos-${#PREBUFFER} ))
                 print "$__start/$__end"
-                LANG=C whatis "$__wrd" &> /dev/null
+                LANG=C whatis "${(z)__section_flag}" "$__term" &> /dev/null
                 print "$?"
             )
             command true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

fast-syntax-highlighting now recognizes manual subsection suffixes such as
`open.2`, `ls.1p`, `printf.3` and highlight them correctly.

`man-db` is known to support subsection suffix.
`mandoc` should not be affected by this commit.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

manpage with subsection suffix is highlighted as error.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

Tested with 
- `man-db` **2.11.2**
- `mandoc` **1.14.6**

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
