### PR TITLE
avoid errors unbound variables and unset parameters

### DIFF
--- a/fast-syntax-highlighting.plugin.zsh
+++ b/fast-syntax-highlighting.plugin.zsh
@@ -45,13 +45,13 @@ typeset -ga _FAST_MAIN_CACHE
 typeset -ga _FAST_COMPLEX_BRACKETS
 
 typeset -g FAST_WORK_DIR=${FAST_WORK_DIR:-${XDG_CACHE_HOME:-~/.cache}/fast-syntax-highlighting}
-: ${FAST_WORK_DIR:=$FAST_BASE_DIR}
+: ${FAST_WORK_DIR:=${FAST_BASE_DIR-}}
 # Expand any tilde in the (supposed) path.
 FAST_WORK_DIR=${~FAST_WORK_DIR}
 
 # Last (currently, possibly) loaded plugin isn't "fast-syntax-highlighting"?
 # And FPATH isn't containing plugin dir?
-if [[ ${zsh_loaded_plugins[-1]} != */fast-syntax-highlighting && -z ${fpath[(r)${0:h}]} ]]
+if [[ ${zsh_loaded_plugins[-1]-} != */fast-syntax-highlighting && -z ${fpath[(r)${0:h}]-} ]]
 then
     fpath+=( "${0:h}" )
 fi
@@ -252,7 +252,7 @@ _zsh_highlight_bind_widgets()
 
   local cur_widget
   for cur_widget in $widgets_to_bind; do
-    case $widgets[$cur_widget] in
+    case ${widgets[$cur_widget]-} in
 
       # Already rebound event: do nothing.
       user:_zsh_highlight_widget_*);;
@@ -279,7 +279,7 @@ _zsh_highlight_bind_widgets()
 
       # Incomplete or nonexistent widget: Bind to z-sy-h directly.
       *) 
-         if [[ $cur_widget == zle-* ]] && [[ -z $widgets[$cur_widget] ]]; then
+         if [[ $cur_widget == zle-* ]] && [[ -z ${widgets[$cur_widget]-} ]]; then
            _zsh_highlight_widget_${cur_widget}() { :; _zsh_highlight }
            zle -N -- $cur_widget _zsh_highlight_widget_$cur_widget
          else
@@ -381,4 +381,4 @@ if [[ $(uname -a) = (#i)*darwin* ]] {
     FAST_HIGHLIGHT[chroma-man]=
 }
 
-[[ $COLORTERM == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null || true
+[[ ${COLORTERM-} == (24bit|truecolor) || ${terminfo[colors]} -eq 16777216 ]] || zmodload zsh/nearcolor &>/dev/null || true


### PR DESCRIPTION
## Description
zsh prints an abundance of errors when `setopt nounset` is enabled and fast-syntax-highlighting is activated. This commit helps to avoid the unnecessary verbosity and fix #49. cases where variables were referenced using `$var` and where `zsh5.9 --no-unset` complained about it have been modified to use `${var-}` syntax

## Related Issue
#49

## How Has This Been Tested?
I tested my changes manually using my default login shell (`zsh -u` at the moment) with my changes to my local copy of the plugin.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
