### PR TITLE
add support for `goawk`

### DIFF
--- a/fast-highlight
+++ b/fast-highlight
@@ -198,6 +198,7 @@ FAST_HIGHLIGHT+=(
 
   chroma-awk           →chroma/-awk.ch
   chroma-gawk          →chroma/-awk.ch
+  chroma-goawk         →chroma/-awk.ch
   chroma-mawk          →chroma/-awk.ch
 
   chroma-source        →chroma/-source.ch


### PR DESCRIPTION
`goawk` ([benhoyt/goawk](https://github.com/benhoyt/goawk)) is a POSIX-compliant AWK interpreter[^1] that can benefit from the same syntax highlighting as the other AWK interpreters[^2] already present in this repository.

[^1]: Note that `goawk` also features a CSV- and TSV-file mode,[^3] which this pull request does not address in terms of highlighting. As a result, CSV- and TSV-file-mode code enclosed by single quotes might appear as if it were highlighted incorrectly or as invalid AWK. However, I believe the advantage of providing proper syntax highlighting for well-formed AWK outweighs this potential edge case and justifies the inclusion of `goawk` as an AWK interpreter.
[^2]: [zdharma-continuum/fast-syntax-highlighting@`371591a7b6`/fast-highlight #L199–L201](https://github.com/zdharma-continuum/fast-syntax-highlighting/blob/371591a7b6f0f3c9501c52a7b566addbfd804d09/fast-highlight#L199-L201)
[^3]: [benhoyt.com/writings/goawk-csv](https://benhoyt.com/writings/goawk-csv) ([archive](https://web.archive.org/web/20230115181935id_/benhoyt.com/writings/goawk-csv))