### PR TITLE
Add '--message' to git commit syntax highlighting

### DIFF
--- a/→chroma/-git.ch
+++ b/→chroma/-git.ch
@@ -155,7 +155,7 @@ fsh__git__chroma__def=(
     subcmd:commit "COMMIT_#_opt // FILE_#_arg // NO_MATCH_#_opt"
 
     "COMMIT_#_opt" "
-              (-m|--message=|-am)
+              (-m|--message=|--message|-am)
                        <<>> NO-OP // ::→chroma/-git-commit-msg-opt-action
                        <<>> NO-OP // ::→chroma/-git-commit-msg-opt-ARG-action
            || (--help|-a|--all|-p|--patch|--reset-author|--short|--branch|


### PR DESCRIPTION
## Description

Git supports adding a message to a commit via `git commit --message`.
Although the man page only mentions `-m "mymessage"` and `--message="mymessage"`, omitting the `=` sign also works.
However `git commit --message "mymessge"` gives wrong highlighting (see issue).

## Related Issue(s)

Fixes zdharma-continuum/fast-syntax-highlighting#47

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
