### PR TITLE
fix(make): colorize targets from imported make-files

### DIFF
--- a/→chroma/-make.ch
+++ b/→chroma/-make.ch
@@ -73,7 +73,8 @@ local -a __lines_list reply2
                 __wrd="${(Q)__wrd}"
 
                 if [[ -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" ]] && \
-                        .fast-make-targets < "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}"
+                       # .fast-make-targets < "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}"
+                       make -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" -pn | .fast-make-targets
                 then
                     if [[ "${reply2[(r)$__wrd]}" ]]; then
                         (( __start=__start_pos-${#PREBUFFER}, __end=__end_pos-${#PREBUFFER}, __start >= 0 )) && reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}correct-subtle]}")

--- a/→chroma/-make.ch
+++ b/→chroma/-make.ch
@@ -73,7 +73,6 @@ local -a __lines_list reply2
                 __wrd="${(Q)__wrd}"
 
                 if [[ -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" ]] && \
-                       # .fast-make-targets < "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}"
                        make -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" -pn | .fast-make-targets
                 then
                     if [[ "${reply2[(r)$__wrd]}" ]]; then


### PR DESCRIPTION
## Description

Old behavior use to parse the content of the invoked `Makefile` unit to define targets.

Such parsing didn't take into account targets from unit imported by the current (ex: targets defined in files imported such as `import ./targets/help.mk`).

New behavior pass the content of the Makefile unit post lexing (aka `make -f Makefile -pn` instead of the plain unit.

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->
No issue created but I could open one if needed 
 
## Motivation and Context <!--- What problem does it solve? -->

My makefiles unit heavily rely on the `include` keyword to DRY up my monorepo. As such, targets defined in included makefile unit arn't recognize by the makefile chroma. 

## Usage examples

```zsh

```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
