### PR TITLE
feat(chroma/make): new makefile colorization caching strategy

### DIFF
--- a/.fast-make-targets
+++ b/.fast-make-targets
@@ -87,10 +87,44 @@ local -a TARGETS
     done
 }
 
-if [[ -z "${FAST_HIGHLIGHT[chroma-make-cache]}" || $(( EPOCHSECONDS - FAST_HIGHLIGHT[chroma-make-cache-born-at] )) -gt 7 ]]; then
-    .make-parseMakefile
-    FAST_HIGHLIGHT[chroma-make-cache-born-at]="$EPOCHSECONDS"
-    FAST_HIGHLIGHT[chroma-make-cache]="${(j:;:)TARGETS}"
+# Cache generated parsing for 1sec per session or globally if configured, per Makefile path.
+if [[ -n "${FAST_HIGHLIGHT[chroma-make-cache-global]}" ]]; then
+    # Determine Makefile path.
+    # TODO: find a way to expand path and resolve alias - this cause deduplicated cache file.
+    local makefile_path
+    makefile_path=${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}
+
+    # If not absolute, resolve to absolute path
+    [[ $makefile_path != /* ]] && makefile_path="$PWD/$makefile_path"
+
+    # Generate a safe hash for the cache file name using sha1sum
+    local makefile_hash
+    makefile_hash=$(print -n -- "$makefile_path" | sha1sum | awk '{print $1}')
+
+    # Generate a sha1sum hash from the input variable
+    local input var val target dep TAB=$'\t' tmp IFS=
+    local input_hash
+    input_hash=$(print -n -- "$input" | sha1sum | awk '{print $1}')
+
+    # Generate the cache file path.
+    local cache_file
+    cache_file="/tmp/fast-highlight-make-cache-${makefile_hash}-${input_hash}"
+
+    if [[ ! -f $cache_file ]]; then
+        # Clean up old cache files.
+        rm -rf /tmp/fast-highlight-make-cache-${makefile_hash}-*
+        # Generate new cache file.
+        .make-parseMakefile "$input"
+        print -r -- "${(j:;:)TARGETS}" >| "$cache_file"
+    fi
+    FAST_HIGHLIGHT[chroma-make-cache]="$(<$cache_file)"
+    FAST_HIGHLIGHT[chroma-make-cache-born-at]="0"
+else
+    if [[ -z "${FAST_HIGHLIGHT[chroma-make-cache]}" || $(( EPOCHSECONDS - FAST_HIGHLIGHT[chroma-make-cache-born-at] )) -gt 7 ]]; then
+        .make-parseMakefile
+        FAST_HIGHLIGHT[chroma-make-cache-born-at]="$EPOCHSECONDS"
+        FAST_HIGHLIGHT[chroma-make-cache]="${(j:;:)TARGETS}"
+    fi
 fi
 
 reply2=( "${(s:;:)FAST_HIGHLIGHT[chroma-make-cache]}" )

--- a/.fast-make-targets
+++ b/.fast-make-targets
@@ -18,7 +18,7 @@ local -a TARGETS
                 rest=${rest[3,-1]}
                 continue
                 ;;
-                (\()          # Variable of the form $(foobar)
+            (\()          # Variable of the form $(foobar)
                 open='('
                 close=')'
                 ;;

--- a/→chroma/-make.ch
+++ b/→chroma/-make.ch
@@ -73,7 +73,7 @@ local -a __lines_list reply2
                 __wrd="${(Q)__wrd}"
 
                 if [[ -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" ]] && \
-                       make -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" -pn | .fast-make-targets
+                       make -f "${FAST_HIGHLIGHT[chroma-make-custom-dir]%/}/${FAST_HIGHLIGHT[chroma-make-custom-file]}" -Rrpq | awk '/^[a-zA-Z0-9][^$#\t=]*:/' | .fast-make-targets
                 then
                     if [[ "${reply2[(r)$__wrd]}" ]]; then
                         (( __start=__start_pos-${#PREBUFFER}, __end=__end_pos-${#PREBUFFER}, __start >= 0 )) && reply+=("$__start $__end ${FAST_HIGHLIGHT_STYLES[${FAST_THEME_NAME}correct-subtle]}")


### PR DESCRIPTION
## Description

Update the way cached makefile metadata are cached.\ 
Up until now, a single cache item (7s TTL) was generated whatever makefile was used.\

This new implementation allows generating a cache item per makefile path + content pair; allowing to get rid of the TTL. 

One may enable the new strategy by setting the following prior to source fast-synthax-highlighting

```sh
typeset -gA FAST_HIGHLIGHT
FAST_HIGHLIGHT[chroma-make-cache-global]=1
```

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

Some comments following https://github.com/zdharma-continuum/fast-syntax-highlighting/pull/81/files (https://github.com/zdharma-continuum/fast-syntax-highlighting/commit/dcee72bb99b422bb8e4510f5087af9c1721392e4#commitcomment-161064002 & other) 



## Motivation and Context <!--- What problem does it solve? -->

Parsing Makefile targets is now expensive because of me, so let's attempt to run it as less as we needs


## Usage examples

```zsh
typeset -gA FAST_HIGHLIGHT
FAST_HIGHLIGHT[chroma-make-cache-global]=1

source ~/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh
```

## How Has This Been Tested?

Locally 🤓 

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
